### PR TITLE
Fix NHTSA fetch via proxy

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
         setLoadingMakes(true);
         setApiError('');
         try {
-          var response = await fetch(`/.netlify/functions/proxy?url=${encodeURIComponent(`https://vpic.nhtsa.dot.gov/api/vehicles/GetMakesForVehicleType/passenger%20car?format=json`)}`);
+          var response = await fetch(`/.netlify/functions/proxy?url=${encodeURIComponent(`https://vpic.nhtsa.dot.gov/api/vehicles/GetMakesForVehicleModelYear/${year}?format=json`)}`);
           var data = await response.json();
           if (data.Results && data.Results.length > 0) {
             setMakes(data.Results.map(function (item) { return item.Make_Name; }).sort());

--- a/netlify/functions/proxy.js
+++ b/netlify/functions/proxy.js
@@ -1,7 +1,26 @@
-[build]
-  command = "npm run build:css"
-  publish = "."
-[[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200
+exports.handler = async function(event, context) {
+  const url = event.queryStringParameters.url;
+  if (!url) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: 'Missing url parameter' })
+    };
+  }
+  try {
+    const response = await fetch(url);
+    const data = await response.text();
+    return {
+      statusCode: response.status,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Content-Type': 'application/json'
+      },
+      body: data
+    };
+  } catch (err) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: 'Failed to fetch proxy url' })
+    };
+  }
+};


### PR DESCRIPTION
## Summary
- replace misplaced content in `netlify/functions/proxy.js` with a real proxy
- request vehicle makes using `GetMakesForVehicleModelYear` endpoint

## Testing
- `npm run build:css` *(fails: tailwindcss not found)*

------
https://chatgpt.com/codex/tasks/task_b_68751b6791dc83318ba1167c69c203ae