### PR TITLE
Restore proxy serverless function

### DIFF
--- a/netlify/functions/proxy.js
+++ b/netlify/functions/proxy.js
@@ -1,7 +1,17 @@
-[build]
-  command = "npm run build:css"
-  publish = "."
-[[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200
+const axios = require('axios');
+
+exports.handler = async (event) => {
+  try {
+    const { url } = event.queryStringParameters;
+    const response = await axios.get(url);
+    return {
+      statusCode: 200,
+      body: JSON.stringify(response.data),
+    };
+  } catch (error) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: 'Failed to fetch data' }),
+    };
+  }
+};


### PR DESCRIPTION
## Summary
- restore the Netlify function `proxy.js` for API requests

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build:css` *(fails: tailwindcss not found)*

------
https://chatgpt.com/codex/tasks/task_b_68751fe5cdf88331861c12b2b1441e7c